### PR TITLE
Update MM.NFT id assignment on uuid & add paths

### DIFF
--- a/cadence/contracts/MonsterMaker.cdc
+++ b/cadence/contracts/MonsterMaker.cdc
@@ -27,7 +27,9 @@ pub contract MonsterMaker: NonFungibleToken {
     //
     pub let CollectionStoragePath: StoragePath
     pub let CollectionPublicPath: PublicPath
+    pub let ProviderPrivatePath: PrivatePath
     pub let MinterStoragePath: StoragePath
+    pub let MinterPrivatePath: PrivatePath
 
     pub struct MonsterComponent {
         pub var background: Int
@@ -82,12 +84,11 @@ pub contract MonsterMaker: NonFungibleToken {
         pub let component: MonsterMaker.MonsterComponent
 
         init(
-            id: UInt64,
             royalties: [MetadataViews.Royalty],
             metadata: {String: AnyStruct},
             component: MonsterMaker.MonsterComponent,    
         ){
-            self.id = id
+            self.id = self.uuid
             self.royalties = royalties
             self.metadata = metadata
             self.component = component
@@ -312,17 +313,18 @@ pub contract MonsterMaker: NonFungibleToken {
 
             // create a new NFT
             var newNFT <- create MonsterMaker.NFT(
-                id: MonsterMaker.totalSupply,
                 royalties: royalties,
                 metadata: metadata,
                 component: component, 
             )
 
+            let mintedID = newNFT.id
+
             // deposit it in the recipient's account using their reference
             recipient.deposit(token: <-newNFT)
 
             emit Minted(
-                id: MonsterMaker.totalSupply,
+                id: mintedID,
                 component: component,
             )
 
@@ -356,7 +358,9 @@ pub contract MonsterMaker: NonFungibleToken {
         // Set our named paths
         self.CollectionStoragePath = /storage/MonsterMakerCollection
         self.CollectionPublicPath = /public/MonsterMakerCollection
+        self.ProviderPrivatePath = /private/MonsterMakerCollectionProvider
         self.MinterStoragePath = /storage/MonsterMakerMinter
+        self.MinterPrivatePath = /private/MonsterMakerMinter
 
         // Create a Collection resource and save it to storage
         let collection <- create Collection()

--- a/cadence/transactions/setup_account.cdc
+++ b/cadence/transactions/setup_account.cdc
@@ -16,7 +16,7 @@ transaction {
             signer.save(<-collection, to: MonsterMaker.CollectionStoragePath)
 
             // create a public capability for the collection
-            signer.link<&MonsterMaker.Collection{NonFungibleToken.CollectionPublic, MonsterMaker.MonsterMakerCollectionPublic, MetadataViews.ResolverCollection}>(MonsterMaker.CollectionPublicPath, target: MonsterMaker.CollectionStoragePath)
+            signer.link<&MonsterMaker.Collection{NonFungibleToken.Receiver, NonFungibleToken.CollectionPublic, MonsterMaker.MonsterMakerCollectionPublic, MetadataViews.ResolverCollection}>(MonsterMaker.CollectionPublicPath, target: MonsterMaker.CollectionStoragePath)
         }
     }
 }


### PR DESCRIPTION
Closes: #3

### Context
As MonsterMaker is increasingly featured in internal demos, we're hoping to make minor updates to the MonsterMaker contract so ids are assigned on uuid. For our use case in gaming, this will help prevent collisions in games with mappings indexed on NFT.id as well as establish consistency with the https://github.com/onflow/flow-nft/pull/126.

Posting PR to this repo as [this PR](https://github.com/dapperlabs/monster-maker/pull/40) to the dapperlabs, but it was noted that the repo will be deprecated in favor of this one.

### Description
Updated NFT.id assignment to pull from the NFT's uuid
Additionally added canonical paths for Provider & Minter PrivatePaths
Since NFT id's are now assigned on uuid, I also updated the Minted event accordingly.

For contributor use:

- [X] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels ](https://github.com/dapperlabs/monster-maker/pull/40)