### PR TITLE
Remove updated contract field for upgradability; Add publish/claim mi…

### DIFF
--- a/cadence/contracts/MonsterMaker.cdc
+++ b/cadence/contracts/MonsterMaker.cdc
@@ -27,9 +27,7 @@ pub contract MonsterMaker: NonFungibleToken {
     //
     pub let CollectionStoragePath: StoragePath
     pub let CollectionPublicPath: PublicPath
-    pub let ProviderPrivatePath: PrivatePath
     pub let MinterStoragePath: StoragePath
-    pub let MinterPrivatePath: PrivatePath
 
     pub struct MonsterComponent {
         pub var background: Int
@@ -358,9 +356,7 @@ pub contract MonsterMaker: NonFungibleToken {
         // Set our named paths
         self.CollectionStoragePath = /storage/MonsterMakerCollection
         self.CollectionPublicPath = /public/MonsterMakerCollection
-        self.ProviderPrivatePath = /private/MonsterMakerCollectionProvider
         self.MinterStoragePath = /storage/MonsterMakerMinter
-        self.MinterPrivatePath = /private/MonsterMakerMinter
 
         // Create a Collection resource and save it to storage
         let collection <- create Collection()
@@ -379,3 +375,4 @@ pub contract MonsterMaker: NonFungibleToken {
         emit ContractInitialized()
     }
 }
+ 

--- a/cadence/transactions/claim_minter_capability.cdc
+++ b/cadence/transactions/claim_minter_capability.cdc
@@ -1,0 +1,16 @@
+import MonsterMaker from "../contracts/MonsterMaker.cdc"
+
+/// Transaction that retrieves an NFTMinter from specified provider with the given name
+/// and stores it at the specified path.
+///
+transaction(capabilityName: String, storagePath: StoragePath, provider: Address) {
+    
+    prepare(signer: AuthAccount) {
+        let minterCap = signer.inbox.claim<&MonsterMaker.NFTMinter>(
+            capabilityName,
+            provider: provider
+        ) ?? panic("No published Capability with given name available from provider ".concat(provider.toString()))
+
+        signer.save(minterCap, to: storagePath)
+    }
+}

--- a/cadence/transactions/publish_minter_capability.cdc
+++ b/cadence/transactions/publish_minter_capability.cdc
@@ -1,0 +1,22 @@
+import MonsterMaker from "../contracts/MonsterMaker.cdc"
+
+/// Transaction that links an NFTMinter at the specified path (if it doesn't already exist),
+/// retrieves it, and publishes it for the specified recipient under the given name
+///
+transaction(capabilityName: String, capabilityPath: CapabilityPath, recipient: Address) {
+    prepare(signer: AuthAccount) {
+        if !signer.getCapability<&MonsterMaker.NFTMinter>(capabilityPath).check() {
+            signer.unlink(capabilityPath)
+            signer.link<&MonsterMaker.NFTMinter>(
+                capabilityPath,
+                target: MonsterMaker.MinterStoragePath
+            )
+        }
+        let minterCap = signer.getCapability<&MonsterMaker.NFTMinter>(capabilityPath)
+        signer.inbox.publish(
+            minterCap,
+            name: capabilityName,
+            recipient: recipient
+        )
+    }
+}


### PR DESCRIPTION
Closes #6 

## Description

Removes fields `ProviderPrivatePath` & `MinterPrivatePath` from the MonsterMaker contract, allowing for the contract to now be redeployed to testnet.

Additionally, the walletless onboarding demo will require an `NFTMinter` Capability, so I've added transactions for linking & publishing of said Capability as well as a transaction allowing the walletless onboarding account to claim & save the Capability.

For contributor use:

- [X] Targeted PR against `master` branch
- [X] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [X] Code follows the [standards mentioned here](https://github.com/onflow/flow-nft/blob/master/CONTRIBUTING.md#styleguides).
- [X] Updated relevant documentation 
- [X] Re-reviewed `Files changed` in the Github PR explorer
- [X] Added appropriate labels 